### PR TITLE
Add support for Apple M2

### DIFF
--- a/smctemp.cc
+++ b/smctemp.cc
@@ -37,6 +37,7 @@
 #include <sys/sysctl.h>
 #include <algorithm>
 #include <array>
+#include <utility>
 
 namespace {
 std::string getCPUModel() {
@@ -407,6 +408,7 @@ double SmcTemp::GetCpuTemp() {
 #elif defined(ARCH_TYPE_ARM64)
   std::vector<std::string> sensors;
   std::vector<std::string> aux_sensors;
+  const std::pair<unsigned int, unsigned int> valid_temperature_limits{10, 120};
 
   const std::string cpumodel = getCPUModel();
   if (cpumodel.find("m2") != std::string::npos) {  // Apple M2
@@ -460,7 +462,7 @@ double SmcTemp::GetCpuTemp() {
   size_t valid_sensor_count = 0;
   for (auto sensor : sensors) {
     auto sensor_value = smc_accessor_.ReadValue(sensor.c_str());
-    if (sensor_value > 0.0) {
+    if (sensor_value >= valid_temperature_limits.first && sensor_value <= valid_temperature_limits.second) {
       temp += sensor_value;
       valid_sensor_count++;
     }
@@ -473,7 +475,7 @@ double SmcTemp::GetCpuTemp() {
   size_t valid_aux_sensor_count = 0;
   for (auto sensor : aux_sensors) {
     auto sensor_value = smc_accessor_.ReadValue(sensor.c_str());
-    if (sensor_value > 0.0) {
+    if (sensor_value > valid_temperature_limits.first && sensor_value < valid_temperature_limits.second) {
       temp += sensor_value;
       valid_aux_sensor_count++;
     }

--- a/smctemp.h
+++ b/smctemp.h
@@ -54,16 +54,20 @@ constexpr UInt32Char_t kSensorTc0a = "Tc0a";
 constexpr UInt32Char_t kSensorTc0b = "Tc0b";
 constexpr UInt32Char_t kSensorTc0x = "Tc0x";
 constexpr UInt32Char_t kSensorTc0z = "Tc0z";
-constexpr UInt32Char_t kSensorTp01 = "Tp01"; // CPU performance core 1 temperature
-constexpr UInt32Char_t kSensorTp05 = "Tp05"; // CPU performance core 2 temperature
-constexpr UInt32Char_t kSensorTp0d = "Tp0D"; // CPU performance core 3 temperature
-constexpr UInt32Char_t kSensorTp0h = "Tp0H"; // CPU performance core 4 temperature
-constexpr UInt32Char_t kSensorTp0l = "Tp0L"; // CPU performance core 5 temperature
-constexpr UInt32Char_t kSensorTp0p = "Tp0P"; // CPU performance core 6 temperature
-constexpr UInt32Char_t kSensorTp0x = "Tp0X"; // CPU performance core 7 temperature
-constexpr UInt32Char_t kSensorTp0b = "Tp0b"; // CPU performance core 8 temperature
-constexpr UInt32Char_t kSensorTp09 = "Tp09"; // CPU efficient core 1 temperature
-constexpr UInt32Char_t kSensorTp0t = "Tp0T"; // CPU efficient core 2 temperature
+constexpr UInt32Char_t kSensorTp01 = "Tp01";
+constexpr UInt32Char_t kSensorTp05 = "Tp05";
+constexpr UInt32Char_t kSensorTp0d = "Tp0D";
+constexpr UInt32Char_t kSensorTp0h = "Tp0H";
+constexpr UInt32Char_t kSensorTp0l = "Tp0L";
+constexpr UInt32Char_t kSensorTp0p = "Tp0P";
+constexpr UInt32Char_t kSensorTp0x = "Tp0X";
+constexpr UInt32Char_t kSensorTp0b = "Tp0b";
+constexpr UInt32Char_t kSensorTp09 = "Tp09";
+constexpr UInt32Char_t kSensorTp0t = "Tp0T";
+constexpr UInt32Char_t kSensorTp0j = "Tp0j";
+constexpr UInt32Char_t kSensorTp0r = "Tp0r";
+constexpr UInt32Char_t kSensorTp0f = "Tp0f";
+constexpr UInt32Char_t kSensorTp0n = "Tp0n";
 #endif
 
 class SmcAccessor {

--- a/smctemp.h
+++ b/smctemp.h
@@ -25,6 +25,8 @@
 
 #include <IOKit/IOKitLib.h>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "smctemp_types.h"
 
@@ -92,6 +94,8 @@ class SmcAccessor {
 
 class SmcTemp {
  private:
+  double CalculateAverageTemperature(const std::vector<std::string>& sensors,
+                                     const std::pair<unsigned int, unsigned int>& limits);
   SmcAccessor smc_accessor_;
 
  public:


### PR DESCRIPTION
Hey @narugit thanks for resurrecting the old smctemp project.
This PR adds support for Apple M2 (my laptop) (8 cores - 4 performance + 4 efficiency). Also adds support for other models based on the sensors app open-source code.
Closes #11

Also adds an option to poll for the temperature values for n times until a given value is returned (special case for some apple m2 models)

Mac Model:
<img width="278" alt="image" src="https://github.com/narugit/smctemp/assets/7375276/c9e95ec8-300c-4da0-b065-e58b27cc93cf">

TG Pro details:
<img width="799" alt="image" src="https://github.com/narugit/smctemp/assets/7375276/57cc5e61-ada8-438d-addf-b41c493f21b4">

smctemp:
<img width="286" alt="image" src="https://github.com/narugit/smctemp/assets/7375276/bc5f79cc-d5e8-48eb-8781-96d401b2520a">




