### PR TITLE
Move print temperature to executable

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1,3 +1,4 @@
+#include <iomanip>
 #include <iostream>
 
 #include "smctemp.h"
@@ -59,7 +60,7 @@ int main(int argc, char *argv[]) {
       }
       break;
     case smctemp::kOpReadCpuTemp:
-      smc_temp.PrintCpuTemp();
+      std::cout << std::fixed << std::setprecision(1) << smc_temp.GetCpuTemp();
       break;
   }
 

--- a/smctemp.cc
+++ b/smctemp.cc
@@ -421,12 +421,5 @@ double SmcTemp::GetCpuTemp() {
   return temp;
 }
 
-
-void SmcTemp::PrintCpuTemp() {
-  double temp;
-  temp = GetCpuTemp();
-  std::cout << std::fixed << std::setprecision(1) << temp;
-}
-
 }
 

--- a/smctemp.h
+++ b/smctemp.h
@@ -89,12 +89,11 @@ class SmcAccessor {
 class SmcTemp {
  private:
   SmcAccessor smc_accessor_;
-  double GetCpuTemp();
 
  public:
   SmcTemp() = default;
   ~SmcTemp() = default;
-  void PrintCpuTemp();
+  double GetCpuTemp();
 };
 
 typedef struct {


### PR DESCRIPTION
In order to include smctemp as a static library in other software (my goal is to add it as a dependency to Kodi to replace the older smc implementation (https://github.com/xbmc/xbmc/blob/70ff020f77f4fecd4a3332cbd81bb3be636c7dee/xbmc/platform/darwin/osx/smc.c#L9) the `SmcTemp` `GetCpuTemp` should be public (or at least protected).

Since the implementation of `PrintCpuTemp` is quite simple (and should be usable only by a cli tool) let's consider moving it to the executable while exposing the public getters.

Should be a no brainer but...your project @narugit, your call :)