### PR TITLE
Add GPU temperature sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## smctemp
-Print CPU temperature on macOS.
+Print CPU and GPU temperatures on macOS.
 
 It works on following macs.
 - arm64 (M2 mac)
@@ -8,6 +8,7 @@ It works on following macs.
 
 ## Acknowledgements
 I took the code from [hholtmann/smcFanControl/smc-command](https://github.com/hholtmann/smcFanControl/tree/ad374ffb1dd088a7676719e53dbd2886f8fafdff/smc-command) and modified it to specialize in temperature acquisition.
+Some of the sensor values were obtained from the [exelban/stats](https://github.com/exelban/stats) project.
 
 ## How to Use
 ```console
@@ -20,14 +21,19 @@ $ smctemp -c
 ## Usage 
 ```console
 $ smctemp -h
-Check Temperature by using Apple System Management Control (Smc) tool 0.1
+Check Temperature by using Apple System Management Control (Smc) tool 0.1.1
 Usage:
-smctemp [options]
+./smctemp [options]
     -c         : list CPU temperatures (Celsius)
+    -g         : list GPU temperatures (Celsius)
     -h         : help
     -l         : list all keys and values
     -v         : version
+    -n         : tries to query the temperature sensors for n times (e.g. -n3) (1 second interval) until a valid value is returned
 
 $ smctemp -c
 64.2
+
+$ smctemp -g
+36.2
 ```

--- a/main.cc
+++ b/main.cc
@@ -9,6 +9,7 @@ void usage(char* prog) {
   std::cout << "Usage:" << std::endl;
   std::cout << prog << " [options]" << std::endl;
   std::cout << "    -c         : list CPU temperatures (Celsius)" << std::endl;
+  std::cout << "    -g         : list GPU temperatures (Celsius)" << std::endl;
   std::cout << "    -h         : help" << std::endl;
   std::cout << "    -l         : list all keys and values" << std::endl;
   std::cout << "    -v         : version" << std::endl;
@@ -25,10 +26,13 @@ int main(int argc, char *argv[]) {
   smctemp::UInt32Char_t  key = { 0 };
   smctemp::SmcVal_t      val;
 
-  while ((c = getopt(argc, argv, "clvhn:")) != -1) {
+  while ((c = getopt(argc, argv, "clvhn:g")) != -1) {
     switch(c) {
       case 'c':
         op = smctemp::kOpReadCpuTemp;
+        break;
+      case 'g':
+        op = smctemp::kOpReadGpuTemp;
         break;
       case 'n':
         if (optarg) {
@@ -71,10 +75,15 @@ int main(int argc, char *argv[]) {
         std::cerr.flags(ef);
       }
       break;
+    case smctemp::kOpReadGpuTemp:
     case smctemp::kOpReadCpuTemp:
       double temp = 0.0;
       while (attempts > 0) {
-        temp = smc_temp.GetCpuTemp();
+        if (op == smctemp::kOpReadCpuTemp) {
+          temp = smc_temp.GetCpuTemp();
+        } else if (op == smctemp::kOpReadGpuTemp) {
+          temp = smc_temp.GetGpuTemp();
+        }
         if (temp > 0.0) {
           break;
         } else {

--- a/smctemp.h
+++ b/smctemp.h
@@ -42,16 +42,22 @@ constexpr uint32_t kKernelIndexSmc = 2;
 constexpr int kOpNone = 0;
 constexpr int kOpList = 1;
 constexpr int kOpReadCpuTemp = 2;
+constexpr int kOpReadGpuTemp = 3;
 
 // List of key and name: 
-// - https://github.com/exelban/stats/blob/0e2e13c626b650ac7743ef620869d2b7857665cd/Modules/Sensors/values.swift
+// - https://github.com/exelban/stats/blob/6b88eb1f60a0eb5b1a7b51b54f044bf637fd785b/Modules/Sensors/values.swift
 // - https://github.com/acidanthera/VirtualSMC/blob/632fec680d996a5dd015afd9acf0ba40f75e69e2/Docs/SMCSensorKeys.txt
 #if defined(ARCH_TYPE_X86_64)
+// CPU
 constexpr UInt32Char_t kSensorTc0d = "TC0D"; // CPU die temperature
 constexpr UInt32Char_t kSensorTc0e = "TC0E"; // CPU PECI die filtered temperature
 constexpr UInt32Char_t kSensorTc0f = "TC0F"; // CPU PECI die temperature filtered then adjusted
 constexpr UInt32Char_t kSensorTc0p = "TC0P"; // CPU proximity temperature
+// GPU
+constexpr UInt32Char_t kSensorTg0d = "TG0D";  // PCH Die Temp
+constexpr UInt32Char_t kSensorTpcd = "TPCD";  // PCH Die Temp (digital)
 #elif defined(ARCH_TYPE_ARM64)
+// CPU
 constexpr UInt32Char_t kSensorTc0a = "Tc0a";
 constexpr UInt32Char_t kSensorTc0b = "Tc0b";
 constexpr UInt32Char_t kSensorTc0x = "Tc0x";
@@ -70,6 +76,13 @@ constexpr UInt32Char_t kSensorTp0j = "Tp0j";
 constexpr UInt32Char_t kSensorTp0r = "Tp0r";
 constexpr UInt32Char_t kSensorTp0f = "Tp0f";
 constexpr UInt32Char_t kSensorTp0n = "Tp0n";
+// GPU
+constexpr UInt32Char_t kSensorTg05 = "Tg05";
+constexpr UInt32Char_t kSensorTg0D = "Tg0D";
+constexpr UInt32Char_t kSensorTg0L = "Tg0L";
+constexpr UInt32Char_t kSensorTg0T = "Tg0T";
+constexpr UInt32Char_t kSensorTg0f = "Tg0f";
+constexpr UInt32Char_t kSensorTg0j = "Tg0j";
 #endif
 
 class SmcAccessor {
@@ -102,6 +115,7 @@ class SmcTemp {
   SmcTemp() = default;
   ~SmcTemp() = default;
   double GetCpuTemp();
+  double GetGpuTemp();
 };
 
 typedef struct {

--- a/smctemp.h
+++ b/smctemp.h
@@ -109,6 +109,7 @@ class SmcTemp {
  private:
   double CalculateAverageTemperature(const std::vector<std::string>& sensors,
                                      const std::pair<unsigned int, unsigned int>& limits);
+  bool IsValidTemperature(double temperature, const std::pair<unsigned int, unsigned int>& limits);
   SmcAccessor smc_accessor_;
 
  public:


### PR DESCRIPTION
This adds support for GPU sensors (Kodi uses the old smctemp project to obtain either the CPU or the GPU average temperature - ref: https://github.com/xbmc/xbmc/blob/master/xbmc/platform/darwin/osx/smc.h#L36-L42 and https://github.com/xbmc/xbmc/blob/d025684d226cb88f1169bf6dfcc60d5fe4312b67/xbmc/guilib/guiinfo/SystemGUIInfo.cpp#L97C1-L104).

Implementation is pretty similar to https://github.com/narugit/smctemp/pull/14 - includes both x86 and M1/M2. SMC registers where obtained from the sensors project as well.
Verified this against the values provided by TGPro:

<img width="735" alt="image" src="https://github.com/narugit/smctemp/assets/7375276/c49434f9-92f7-4e55-ad2d-440008c1bdfe">

<img width="304" alt="image" src="https://github.com/narugit/smctemp/assets/7375276/24c8f23d-b266-4e73-a365-14881a6f2ff6">

@joshuataylor your feedback is also appreciated here
Hopefully this one can be considered as well :)