### PR TITLE
Allow building a static lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 smctemp
 smctemp.dSYM
+*.a
 *.o
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 CXX = g++
 CXXFLAGS = -Wall -std=c++17 -g -framework IOKit
 EXES = smctemp
-DEST = /usr/local/bin
+STATIC_LIB := libsmctemp.a
+DEST_PREFIX := /usr/local
+AR := ar
+ARFLAGS := rc
+RANLIB := ranlib
 
 ARCH := $(shell uname -m)
 PROCESS_IS_TRANSLATED := $(shell sysctl -in sysctl.proc_translated)
@@ -18,10 +22,22 @@ else
 	$(error Not support architecture: $(ARCH))
 endif
 
+OBJS := smctemp.o \
+        smctemp_string.o
+
+HEADERS := smctemp.h \
+           smctemp_string.h \
+           smctemp_types.h
+
 all: $(EXES)
 
-$(EXES): smctemp_string.o smctemp.o main.cc
-	$(CXX) $(CXXFLAGS) -o $(EXES) smctemp.o smctemp_string.o main.cc
+$(EXES): $(OBJS) main.cc
+	$(CXX) $(CXXFLAGS) -o $(EXES) $(OBJS) main.cc
+
+staticlib: $(OBJS)
+	$(RM) $(STATIC_LIB)
+	$(AR) $(ARFLAGS) $(STATIC_LIB) $^
+	$(RANLIB) $(STATIC_LIB)
 
 smctemp.o: smctemp_string.h smctemp.h smctemp.cc
 	$(CXX) $(CXXFLAGS) -o smctemp.o -c smctemp.cc
@@ -30,10 +46,16 @@ smctemp_string.o: smctemp_string.h smctemp_string.cc
 	$(CXX) $(CXXFLAGS) -o smctemp_string.o -c smctemp_string.cc
 
 install: $(EXES)
-	install -d $(DEST)
-	install -m 0755 $(EXES) $(DEST)
+	install -d $(DEST_PREFIX)/bin
+	install -m 0755 $(EXES) $(DEST_PREFIX)/bin
+
+installstaticlib: $(STATIC_LIB)
+	install -d $(DEST_PREFIX)/lib
+	install -d $(DEST_PREFIX)/include
+	install -m 0644 $(STATIC_LIB) $(DEST_PREFIX)/lib
+	install -m 0644 $(HEADERS) $(DEST_PREFIX)/include
 
 clean:
-	rm -rf $(EXES) smctemp.o smctemp_string.o smctemp.dSYM
+	rm -rf $(EXES) smctemp.o smctemp_string.o smctemp.dSYM $(STATIC_LIB)
 
 .PHONY: clean


### PR DESCRIPTION
Hey @narugit, thanks for merging the gpu PR.
This is my last PR on the queue. I understand if you don't think it is of any value since it's pretty external to the tool (since it is a cli tool/executable). Regardless, I think it's better to push it upstream instead of carrying the patch around (and it is really small anyway).

It allows to build the project (except the executable) as a static library so that it can be included/linked in external software. With this I can include it as a dependency on Kodi and replace our old smc code (which I plan to do this week - have a small PoC that needs cleanup).

I'd ask you to please tag a new version/release after this one is merged (or refused) since it is easier for us to control the source tarballs on the mirrors.

Thanks for all your help with the recent PRs