### PR TITLE
[GPU] Add missing sensors for mac mini m1

### DIFF
--- a/smctemp.cc
+++ b/smctemp.cc
@@ -515,6 +515,9 @@ double SmcTemp::GetGpuTemp() {
     sensors.emplace_back(static_cast<std::string>(kSensorTg0D));  // GPU 2
     sensors.emplace_back(static_cast<std::string>(kSensorTg0L));  // GPU 3
     sensors.emplace_back(static_cast<std::string>(kSensorTg0T));  // GPU 4
+    // ref: runtime detected on a M1 mac mini
+    sensors.emplace_back(static_cast<std::string>(kSensorTg1b));  // GPU 5
+    sensors.emplace_back(static_cast<std::string>(kSensorTg4b));  // GPU 6
   } else {
     // not supported
     return temp;

--- a/smctemp.h
+++ b/smctemp.h
@@ -77,6 +77,8 @@ constexpr UInt32Char_t kSensorTp0r = "Tp0r";
 constexpr UInt32Char_t kSensorTp0f = "Tp0f";
 constexpr UInt32Char_t kSensorTp0n = "Tp0n";
 // GPU
+constexpr UInt32Char_t kSensorTg1b = "Tg1b";
+constexpr UInt32Char_t kSensorTg4b = "Tg4b";
 constexpr UInt32Char_t kSensorTg05 = "Tg05";
 constexpr UInt32Char_t kSensorTg0D = "Tg0D";
 constexpr UInt32Char_t kSensorTg0L = "Tg0L";


### PR DESCRIPTION
Hey @narugit,

Hope you're doing well. Unfortunately while doing https://github.com/xbmc/xbmc/pull/23770 I found out the gpu temperature tests are failing on our CI. The CI runs on mac minis (M1 CPU).
Runtime testing it (`smctemp -l`) I figure out those must be the two sensors reported by TGPro for the GPU (they are even the only ones starting with `Tg`). Interesting stuff - the OS only seems to report data to those sensors when the GPU is under load (otherwise it reports 0.0). TGPro, when the GPU doesn't have any load reports a static 30.0ºC which also matches the average temperature of the machine (the overall sensors the app has combined). So this pretty much indicates they are also using the same strategy smctemp is doing but simply use a fallback temperature when there's no data.
When the GPU is under load the temperature match the one reported by TGPro pretty close!