### PR TITLE
feat: add fail soft option to store valid temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Usage:
     -g         : list GPU temperatures (Celsius)
     -h         : help
     -l         : list all keys and values
+    -f         : fail-soft mode to store recent valid sensor value
     -v         : version
     -n         : tries to query the temperature sensors for n times (e.g. -n3) (1 second interval) until a valid value is returned
 

--- a/smctemp.h
+++ b/smctemp.h
@@ -119,14 +119,21 @@ class SmcTemp {
  private:
   double CalculateAverageTemperature(const std::vector<std::string>& sensors,
                                      const std::pair<unsigned int, unsigned int>& limits);
-  bool IsValidTemperature(double temperature, const std::pair<unsigned int, unsigned int>& limits);
+  bool StoreValidTemperature(double temperature, std::string file_name);
   SmcAccessor smc_accessor_;
+  bool is_fail_soft_;
+  const std::string storage_path_ = "/tmp/smctemp/";
+  const std::string cpu_file_ = "cpu_temperature.txt";
+  const std::string gpu_file_ = "gpu_temperature.txt";
 
  public:
-  SmcTemp() = default;
+  explicit SmcTemp(bool isFailSoft);
   ~SmcTemp() = default;
   double GetCpuTemp();
   double GetGpuTemp();
+  double GetLastValidCpuTemp();
+  double GetLastValidGpuTemp();
+  bool IsValidTemperature(double temperature, const std::pair<unsigned int, unsigned int>& limits);
 };
 
 typedef struct {


### PR DESCRIPTION
### About
- Add fail soft option (`-f`) to store valid temperature
- This option would be helpful with M2 Mac whose sensor is not stable (See also https://github.com/narugit/smctemp/issues/32)