### PR TITLE
Also check for Xcode ARM64 preprocessor macros

### DIFF
--- a/smctemp.cc
+++ b/smctemp.cc
@@ -36,7 +36,7 @@
 
 #include "smctemp_string.h"
 
-#if defined(ARCH_TYPE_ARM64)
+#if defined(ARCH_TYPE_ARM64) || defined(__arm64__)
 #include <sys/sysctl.h>
 #include <algorithm>
 #include <array>
@@ -435,7 +435,7 @@ double SmcTemp::CalculateAverageTemperature(const std::vector<std::string>& sens
 
 double SmcTemp::GetCpuTemp() {
   double temp = 0.0;
-#if defined(ARCH_TYPE_X86_64)
+#if defined(ARCH_TYPE_X86_64) || defined(__x86_64__)
   const std::pair<unsigned int, unsigned int> valid_temperature_limits{0, 110};
   // The reason why I prefer CPU die temperature to CPU proximity temperature:
   // https://github.com/narugit/smctemp/issues/2
@@ -459,7 +459,7 @@ double SmcTemp::GetCpuTemp() {
     StoreValidTemperature(temp, cpu_file_);
     return temp;
   }
-#elif defined(ARCH_TYPE_ARM64)
+#elif defined(ARCH_TYPE_ARM64) || defined(__arm64__)
   std::vector<std::string> sensors;
   std::vector<std::string> aux_sensors;
   const std::pair<unsigned int, unsigned int> valid_temperature_limits{10, 120};
@@ -561,7 +561,7 @@ double SmcTemp::GetCpuTemp() {
 
 double SmcTemp::GetGpuTemp() {
   double temp = 0.0;
-#if defined(ARCH_TYPE_X86_64)
+#if defined(ARCH_TYPE_X86_64) || defined(__x86_64__)
   const std::pair<unsigned int, unsigned int> valid_temperature_limits{0, 110};
   temp = smc_accessor_.ReadValue(kSensorTG0D);
   if (IsValidTemperature(temp, valid_temperature_limits)) {
@@ -573,7 +573,7 @@ double SmcTemp::GetGpuTemp() {
     StoreValidTemperature(temp, gpu_file_);
     return temp;
   }
-#elif defined(ARCH_TYPE_ARM64)
+#elif defined(ARCH_TYPE_ARM64) || defined(__arm64__)
   std::vector<std::string> sensors;
   const std::pair<unsigned int, unsigned int> valid_temperature_limits{10, 120};
   const std::string cpumodel = getCPUModel();

--- a/smctemp.h
+++ b/smctemp.h
@@ -47,7 +47,7 @@ constexpr int kOpReadGpuTemp = 3;
 // List of key and name: 
 // - https://github.com/exelban/stats/blob/6b88eb1f60a0eb5b1a7b51b54f044bf637fd785b/Modules/Sensors/values.swift
 // - https://github.com/acidanthera/VirtualSMC/blob/632fec680d996a5dd015afd9acf0ba40f75e69e2/Docs/SMCSensorKeys.txt
-#if defined(ARCH_TYPE_X86_64)
+#if defined(ARCH_TYPE_X86_64) || defined(__x86_64__)
 // CPU
 constexpr UInt32Char_t kSensorTC0D = "TC0D";  // CPU die temperature
 constexpr UInt32Char_t kSensorTC0E = "TC0E";  // CPU PECI die filtered temperature
@@ -56,7 +56,7 @@ constexpr UInt32Char_t kSensorTC0P = "TC0P";  // CPU proximity temperature
 // GPU
 constexpr UInt32Char_t kSensorTG0D = "TG0D";  // PCH Die Temp
 constexpr UInt32Char_t kSensorTPCD = "TPCD";  // PCH Die Temp (digital)
-#elif defined(ARCH_TYPE_ARM64)
+#elif defined(ARCH_TYPE_ARM64) || defined(__arm64__)
 // CPU
 constexpr UInt32Char_t kSensorTc0a = "Tc0a";
 constexpr UInt32Char_t kSensorTc0b = "Tc0b";


### PR DESCRIPTION
Changed:

#if defined(ARCH_TYPE_ARM64)

to:

#if defined(ARCH_TYPE_ARM64) || defined(__arm64__)