### PR TITLE
ci: add build workflow to verify compilation on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Show toolchain info
+      - name: Show build environment
         run: |
-          uname -m
           sw_vers
+          uname -m
+          sysctl -n machdep.cpu.brand_string
           g++ --version
 
       - name: Build binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+on: [pull_request]
+jobs:
+  build:
+    name: runner / build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15, macos-26]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Show toolchain info
+        run: |
+          uname -m
+          sw_vers
+          g++ --version
+
+      - name: Build binary
+        run: make
+
+      - name: Build static library
+        run: make staticlib
+
+      - name: Verify artifacts
+        run: |
+          file smctemp
+          file libsmctemp.a
+          ./smctemp -h || true


### PR DESCRIPTION
## Summary
- Add `.github/workflows/build.yml` to run `make` and `make staticlib` on pull requests.
- Matrix runs on `macos-15` and `macos-26`.
- Previously, PR checks only ran cpplint and misspell via reviewdog; compilation was not verified.